### PR TITLE
Cast string rather than calling toString directly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1",
         "spomky-labs/base64url": "^1.0",
-        "spomky-labs/cbor-php": "^0.0@dev"
+        "spomky-labs/cbor-php": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
         convertWarningsToExceptions="true"
         processIsolation="false"
         stopOnFailure="false"
-        syntaxCheck="true"
         bootstrap="vendor/autoload.php"
         colors="true">
     <testsuites>

--- a/tests/Unit/KeyHandleTest.php
+++ b/tests/Unit/KeyHandleTest.php
@@ -32,6 +32,6 @@ final class KeyHandleTest extends TestCase
 
         self::assertEquals('foo', $handle->getValue());
         self::assertEquals('foo', $handle->jsonSerialize());
-        self::assertEquals('foo', $handle->__toString());
+        self::assertEquals('foo', (string) $handle);
     }
 }

--- a/tests/Unit/PublicKeyTest.php
+++ b/tests/Unit/PublicKeyTest.php
@@ -32,6 +32,6 @@ final class PublicKeyTest extends TestCase
 
         self::assertEquals('foo', $key->getValue());
         self::assertEquals('foo', $key->jsonSerialize());
-        self::assertEquals('foo', $key->__toString());
+        self::assertEquals('foo', (string) $key);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no <!-- #-prefixed issue number(s), if any -->
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests added   |  <!--highly recommended for new features-->
| Doc PR        |  <!--highly recommended for new features-->

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->

- Remove `syntaxcheck` attribute because the latest PHPUnit version is not allowed in `phpunit.xml.dist`.
- Using the casting `string` to call the magic method `__toString` because I think it makes code more readable.
- Because the `spomky-labs/cbor-php` package has not released version, it should set the `dev-master` at this moment.